### PR TITLE
Integrate ACE_CONF lump into the resulting WAD automagically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.o
 *.zip
 code_dev/
+
+ACE_CONF.conf
+
+*~

--- a/ACE_CONF.conf.example
+++ b/ACE_CONF.conf.example
@@ -1,0 +1,1 @@
+doomtex.workaround 1

--- a/exploit/makefile
+++ b/exploit/makefile
@@ -4,7 +4,7 @@ OBJ1 = ldr1.o
 CC=gcc -m32 -nostdlib
 CFLAGS=${OPT}
 
-build: ${program}.wad
+build: clean ${program}.wad
 
 clean:
 	rm -f *.o ${program}.*
@@ -19,4 +19,3 @@ ${program}.wad: ${program}.l0 ${program}.l1
 	objcopy -O binary --only-section=.text ${program}.l0 ${program}.b0
 	objcopy -O binary --only-section=.text ${program}.l1 ${program}.b1
 	./wadgen.py nhax.b0 nhax.b1 nhax.wad
-

--- a/exploit/wadgen.py
+++ b/exploit/wadgen.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
+
 import sys
+import os
+
 from collections import OrderedDict
 from struct import pack
 from struct import unpack_from
@@ -7,100 +10,110 @@ from struct import pack_into
 
 # special lump
 data_pnames = b"\x01\x00\x00\x00" + b"ACE_LDR0"
-# dummy code
-data_fakecode = b"\x04\x00\x00\x00\x0F\x0B"
 
 # primitive WAD file stuff
 class kgWadFile:
-	lump = OrderedDict()
-	verbose = True
+        lump = OrderedDict()
+        verbose = True
 
-	def lumpFromBuff(self, lumpname, data):
-		size = len(data)
-		lmp = {}
-		lmp["size"] = size
-		padsize = size + 3
-		padsize &= ~3
-		lmp["padsize"] = padsize
-		lmp["data"] = bytes(data) + b"\x00" * (padsize - size)
-		self.lump[lumpname] = lmp
-		if self.verbose:
-			print("added", lumpname, ",", size, "B")
+        def lumpFromBuff(self, lumpname, data):
+                size = len(data)
+                lmp = {}
+                lmp["size"] = size
+                padsize = size + 3
+                padsize &= ~3
+                lmp["padsize"] = padsize
+                lmp["data"] = bytes(data) + b"\x00" * (padsize - size)
+                self.lump[lumpname] = lmp
+                if self.verbose:
+                        print("added", lumpname, ",", size, "B")
 
-	def lumpFromFile(self, lumpname, filename):
-		with open(filename, "rb") as f:
-			contents = f.read()
-		self.lumpFromBuff(lumpname, contents)
+        def lumpFromFile(self, lumpname, filename):
+                with open(filename, "rb") as f:
+                        contents = f.read()
+                self.lumpFromBuff(lumpname, contents)
 
-	def saveFile(self, filename):
-		if self.verbose:
-			print("saving", len(self.lump), "entries")
-		offset = 12
-		for key in self.lump:
-			offset += self.lump[key]["padsize"]
-		with open(filename, "wb") as f:
-			# header
-			data = pack("<III", 0x44415750, len(self.lump), offset)
-			f.write(data)
-			# data
-			for key in self.lump:
-				f.write(self.lump[key]["data"])
-			# directory
-			offset = 12
-			for key in self.lump:
-				data = pack("<II", offset, self.lump[key]["size"])
-				f.write(data)
-				data = bytearray(8)
-				pack_into("8s", data, 0, key.encode('utf-8'))
-				f.write(data)
-				offset += self.lump[key]["padsize"]
+        def saveFile(self, filename):
+                if self.verbose:
+                        print("saving", len(self.lump), "entries")
+
+                with open(filename, "wb") as f:
+                        dir_offset = 12
+                        
+                        # WAD header.
+                        data = pack("<III", 0x44415750, len(self.lump), dir_offset)
+                        f.write(data)
+
+                        file_offset = dir_offset + 16 * len(self.lump)
+
+                        # Files.
+                        for key in self.lump:
+                                data = pack("<II", file_offset, self.lump[key]["size"])
+                                f.write(data)
+                                
+                                data = bytearray(8)
+                                pack_into("8s", data, 0, key.encode('utf-8'))
+                                f.write(data)
+
+                                file_offset += self.lump[key]["padsize"]
+                                
+                        # Data.
+                        for key in self.lump:
+                                f.write(self.lump[key]["data"])
 
 # convert binary to special Doom 'patch'
 def convert_code(filename):
-	# load the file
-	with open(filename, "rb") as f:
-		code = bytearray()
-		code += f.read()
+        # load the file
+        with open(filename, "rb") as f:
+                code = bytearray()
+                code += f.read()
 
-	print("code size", len(code), "B")
+        print("code size", len(code), "B")
 
-	if len(code) > 256:
-		raise Exception("Loader 0 size is too big!")
+        if len(code) > 256:
+                raise Exception("Loader 0 size is too big!")
 
-	# generate output
-	ret = bytearray(688)
-	index = 0
+        # generate output
+        ret = bytearray(688)
+        index = 0
 
-	# header
-	pack_into("<Q", ret, 0, 0x80)
-	index += 8
+        # header
+        pack_into("<Q", ret, 0, 0x80)
+        index += 8
 
-	# contents
-	for i in range(0,len(code)//2):
-		value, = unpack_from("<H", code, i * 2)
-		value += 0x10000
-		value -= 3
-		value &= 0xFFFF
-		pack_into("<I", ret, index, value)
-		index += 4
+        # contents
+        for i in range(0,len(code)//2):
+                value, = unpack_from("<H", code, i * 2)
+                value += 0x10000
+                value -= 3
+                value &= 0xFFFF
+                pack_into("<I", ret, index, value)
+                index += 4
 
-	return ret
+        return ret
 
 # check arguments
 if len(sys.argv) != 4:
-	print("usage:", sys.argv[0], "loader0.bin loader1.bin output.wad")
-	exit(1)
+        print("usage:", sys.argv[0], "loader0.bin loader1.bin output.wad")
+        exit(1)
 
 loader0 = convert_code(sys.argv[1])
 
 # create WAD file
 wadfile = kgWadFile()
-wadfile.lumpFromBuff("ACE_CODE", data_fakecode)
+wadfile.lumpFromFile("ACE_CODE", "../engine/code.lmp")
 wadfile.lumpFromBuff("ACE_LDR0", loader0)
 wadfile.lumpFromFile("ACE_LDR1", sys.argv[2])
 wadfile.lumpFromBuff("PNAMES", data_pnames)
 wadfile.lumpFromFile("TEXTURE1", "texture1.lmp")
 
+ACE_CONF_PATH = "../ACE_CONF.conf"
+
+if os.path.exists(ACE_CONF_PATH):
+        print("Including our own copy of ACE_CONF lump into the WAD")
+        wadfile.lumpFromFile("ACE_CONF", ACE_CONF_PATH)
+else:
+        print("Skipping ACE_CONF lump since it doesn't exist")
+
 # done
 wadfile.saveFile(sys.argv[3])
-


### PR DESCRIPTION
In my use case, this reduces the manual labor of inserting a `doomtex.workaround 1` every time the WAD is recompiled. For other developers, there could be a lot more configuration going on.

Another thing is inserting the resulting `code.lmp` from the exploit. This also happens automagically now. I kinda forgot to include this in the commit message.